### PR TITLE
added treasury support and basic spending limits + gui

### DIFF
--- a/common/defines/graphic/spending_graphics.txt
+++ b/common/defines/graphic/spending_graphics.txt
@@ -1,0 +1,4 @@
+NGui = {
+    # Can be deleted to simplify
+    EVENT_OPTIONS_SHOWN_HIDE_UNAVAILABLE = 8
+}

--- a/common/on_action/spending_defaults.txt
+++ b/common/on_action/spending_defaults.txt
@@ -1,0 +1,15 @@
+﻿on_character_game_start = {
+    if = {
+        limit = { is_player = yes }
+        # Set the default value if not set yet
+        if = {
+            limit = { 
+                NOT = { has_variable = spending_limit }
+            }
+            set_variable = { 
+                name = spending_limit 
+                value = monumental_gold_value 
+            }
+        }
+    }
+}

--- a/common/scripted_effects/build_scripted_effects.txt
+++ b/common/scripted_effects/build_scripted_effects.txt
@@ -1,7 +1,11 @@
 ﻿clrbnit_magic_add_hillside_grazing_building_effect = {
     if = {
         limit = {
-            prev = { gold > cheap_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = hillside_grazing_01
@@ -17,21 +21,29 @@
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = hillside_grazing_01
-        prev = { remove_short_term_gold = cheap_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_2_cost }
+            }
             has_building = hillside_grazing_01
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = hillside_grazing_02
-        prev = { remove_short_term_gold = cheap_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_2_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_3_cost }
+            }
             has_building = hillside_grazing_02
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -40,11 +52,15 @@
             }
         }
         add_building = hillside_grazing_03
-        prev = { remove_short_term_gold = cheap_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_3_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_4_cost }
+            }
             has_building = hillside_grazing_03
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -53,11 +69,15 @@
             }
         }
         add_building = hillside_grazing_04
-        prev = { remove_short_term_gold = cheap_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_4_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_5_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_5_cost }
+            }
             has_building = hillside_grazing_04
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -66,11 +86,15 @@
             }
         }
         add_building = hillside_grazing_05
-        prev = { remove_short_term_gold = cheap_building_tier_5_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_5_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_6_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_6_cost }
+            }
             has_building = hillside_grazing_05
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -79,11 +103,15 @@
             }
         }
         add_building = hillside_grazing_06
-        prev = { remove_short_term_gold = cheap_building_tier_6_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_6_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_7_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_7_cost }
+            }
             has_building = hillside_grazing_06
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -92,11 +120,15 @@
             }
         }
         add_building = hillside_grazing_07
-        prev = { remove_short_term_gold = cheap_building_tier_7_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_7_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_8_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_8_cost }
+            }
             has_building = hillside_grazing_07
             building_hillside_grazing_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -105,7 +137,7 @@
             }
         }
         add_building = hillside_grazing_08
-        prev = { remove_short_term_gold = cheap_building_tier_8_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_8_cost }
     }
 }
 
@@ -113,7 +145,11 @@
 clrbnit_magic_add_breweries_building_effect = {
     if = {
         limit = {
-            prev = { gold > normal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = breweries_01
@@ -129,11 +165,15 @@ clrbnit_magic_add_breweries_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = breweries_01
-        prev = { remove_short_term_gold = normal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_1_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost }
+            }
             has_building = breweries_01
             building_breweries_requirement = { NUMBER = 01 }
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -142,11 +182,15 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_02
-        prev = { remove_short_term_gold = normal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_2_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost }
+            }
             has_building = breweries_02
             building_breweries_requirement = { NUMBER = 02 }
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -155,11 +199,15 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_03
-        prev = { remove_short_term_gold = normal_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_3_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost }
+            }
             has_building = breweries_03
             building_breweries_requirement = { NUMBER = 02 }
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -168,11 +216,15 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_04
-        prev = { remove_short_term_gold = normal_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_4_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_5_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost }
+            }
             has_building = breweries_04
             building_breweries_requirement = { NUMBER = 03 }
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -181,11 +233,15 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_05
-        prev = { remove_short_term_gold = normal_building_tier_5_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_5_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_6_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost }
+            }
             has_building = breweries_05
             building_breweries_requirement = { NUMBER = 03 }
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -194,11 +250,15 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_06
-        prev = { remove_short_term_gold = normal_building_tier_6_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_6_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_7_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost }
+            }
             has_building = breweries_06
             building_breweries_requirement = { NUMBER = 04 }
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -207,11 +267,15 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_07
-        prev = { remove_short_term_gold = normal_building_tier_7_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_7_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_8_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost }
+            }
             has_building = breweries_07
             building_breweries_requirement = { NUMBER = 04 }
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -220,14 +284,18 @@ clrbnit_magic_add_breweries_building_effect = {
             }
         }
         add_building = breweries_08
-        prev = { remove_short_term_gold = normal_building_tier_8_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_8_cost }
     }
 }
 
 clrbnit_magic_add_murex_farms_building_effect = {
     if = {
         limit = {
-            prev = { gold > normal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = murex_farm_01
@@ -243,84 +311,116 @@ clrbnit_magic_add_murex_farms_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = murex_farm_01
-        prev = { remove_short_term_gold = normal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost }
+            }
             has_building = murex_farm_01
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = murex_farm_02
-        prev = { remove_short_term_gold = normal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_2_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost }
+            }
             has_building = murex_farm_02
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
         }
         add_building = murex_farm_03
-        prev = { remove_short_term_gold = normal_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_3_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost }
+            }
             has_building = murex_farm_03
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
         }
         add_building = murex_farm_04
-        prev = { remove_short_term_gold = normal_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_4_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_5_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost }
+            }
             has_building = murex_farm_04
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
         }
         add_building = murex_farm_05
-        prev = { remove_short_term_gold = normal_building_tier_5_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_5_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_6_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost }
+            }
             has_building = murex_farm_05
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
         }
         add_building = murex_farm_06
-        prev = { remove_short_term_gold = normal_building_tier_6_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_6_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_7_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost }
+            }
             has_building = murex_farm_06
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
         }
         add_building = murex_farm_07
-        prev = { remove_short_term_gold = normal_building_tier_7_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_7_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_8_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost }
+            }
             has_building = murex_farm_07
             building_murex_farm_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
         }
         add_building = murex_farm_08
-        prev = { remove_short_term_gold = normal_building_tier_8_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_8_cost }
     }
 }
 
 clrbnit_magic_add_pastures_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = pastures_01
@@ -336,11 +436,15 @@ clrbnit_magic_add_pastures_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = pastures_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = pastures_01
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -349,11 +453,15 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = pastures_02
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -362,11 +470,15 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = pastures_03
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -375,11 +487,15 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = pastures_04
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -388,11 +504,15 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = pastures_05
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -401,11 +521,15 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = pastures_06
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -414,11 +538,15 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = pastures_07
             building_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -427,14 +555,18 @@ clrbnit_magic_add_pastures_building_effect = {
             }
         }
         add_building = pastures_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_hospices_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = hospices_01
@@ -449,11 +581,15 @@ clrbnit_magic_add_hospices_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = hospices_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = hospices_01
             building_requirement_castle_city_church = { LEVEL = 01 }
             prev.culture = {
@@ -461,11 +597,15 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = hospices_02
             building_requirement_castle_city_church = { LEVEL = 02 }
             prev.culture = {
@@ -473,11 +613,15 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = hospices_03
             building_requirement_castle_city_church = { LEVEL = 02 }
             prev.culture = {
@@ -485,11 +629,15 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = hospices_04
             building_requirement_castle_city_church = { LEVEL = 03 }
             prev.culture = {
@@ -497,11 +645,15 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = hospices_05
             building_requirement_castle_city_church = { LEVEL = 03 }
             prev.culture = {
@@ -509,11 +661,15 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = hospices_06
             building_requirement_castle_city_church = { LEVEL = 04 }
             prev.culture = {
@@ -521,11 +677,15 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = hospices_07
             building_requirement_castle_city_church = { LEVEL = 04 }
             prev.culture = {
@@ -533,14 +693,18 @@ clrbnit_magic_add_hospices_building_effect = {
             }
         }
         add_building = hospices_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_hunting_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = hunting_grounds_01
@@ -556,11 +720,15 @@ clrbnit_magic_add_hunting_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = hunting_grounds_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = hunting_grounds_01
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -569,11 +737,15 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = hunting_grounds_02
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -582,11 +754,15 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = hunting_grounds_03
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -595,11 +771,15 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = hunting_grounds_04
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -608,11 +788,15 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = hunting_grounds_05
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -621,11 +805,15 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = hunting_grounds_06
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -634,11 +822,15 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = hunting_grounds_07
             building_hunting_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -647,13 +839,17 @@ clrbnit_magic_add_hunting_building_effect = {
             }
         }
         add_building = hunting_grounds_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 clrbnit_magic_add_qanats_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = qanats_01
@@ -675,76 +871,108 @@ clrbnit_magic_add_qanats_building_effect = {
             }
         }
         add_building = qanats_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = qanats_01
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = qanats_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = qanats_02
             building_requirement_castle_city_church = { LEVEL = 02 }
         }
         add_building = qanats_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = qanats_03
             building_requirement_castle_city_church = { LEVEL = 02 }
         }
         add_building = qanats_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = qanats_04
             building_requirement_castle_city_church = { LEVEL = 03 }
         }
         add_building = qanats_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = qanats_05
             building_requirement_castle_city_church = { LEVEL = 03 }
         }
         add_building = qanats_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = qanats_06
             building_requirement_castle_city_church = { LEVEL = 04 }
         }
         add_building = qanats_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = qanats_07
             building_requirement_castle_city_church = { LEVEL = 04 }
         }
         add_building = qanats_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 clrbnit_magic_add_orchards_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = orchards_01
@@ -760,11 +988,15 @@ clrbnit_magic_add_orchards_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = orchards_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = orchards_01
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -773,11 +1005,15 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = orchards_02
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -786,11 +1022,15 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = orchards_03
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -799,11 +1039,15 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = orchards_04
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -812,11 +1056,15 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = orchards_05
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -825,11 +1073,15 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = orchards_06
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -838,11 +1090,15 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = orchards_07
             building_orchards_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -851,14 +1107,18 @@ clrbnit_magic_add_orchards_building_effect = {
             }
         }
         add_building = orchards_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_farm_estates_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = farm_estates_01
@@ -874,11 +1134,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = farm_estates_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = farm_estates_01
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -887,11 +1151,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = farm_estates_02
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -900,11 +1168,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = farm_estates_03
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -913,11 +1185,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = farm_estates_04
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -926,11 +1202,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = farm_estates_05
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -939,11 +1219,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = farm_estates_06
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -952,11 +1236,15 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = farm_estates_07
             building_farm_estates_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -965,14 +1253,18 @@ clrbnit_magic_add_farm_estates_building_effect = {
             }
         }
         add_building = farm_estates_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_military_camps_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = military_camps_01
@@ -988,11 +1280,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = military_camps_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = military_camps_01
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1001,11 +1297,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = military_camps_02
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1014,11 +1314,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = military_camps_03
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1027,11 +1331,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = military_camps_04
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1040,11 +1348,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = military_camps_05
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1053,11 +1365,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = military_camps_06
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1066,11 +1382,15 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = military_camps_07
             building_military_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1079,14 +1399,18 @@ clrbnit_magic_add_military_camps_building_effect = {
             }
         }
         add_building = military_camps_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_regimental_grounds_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = regimental_grounds_01
@@ -1102,11 +1426,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = regimental_grounds_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = regimental_grounds_01
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1115,11 +1443,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = regimental_grounds_02
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1128,11 +1460,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = regimental_grounds_03
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1141,11 +1477,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = regimental_grounds_04
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1154,11 +1494,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = regimental_grounds_05
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1167,11 +1511,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = regimental_grounds_06
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1180,11 +1528,15 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = regimental_grounds_07
             building_regimental_grounds_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1193,14 +1545,18 @@ clrbnit_magic_add_regimental_grounds_building_effect = {
             }
         }
         add_building = regimental_grounds_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_ramparts_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = ramparts_01
@@ -1216,11 +1572,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = ramparts_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = ramparts_01
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1229,11 +1589,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = ramparts_02
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1242,11 +1606,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = ramparts_03
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1255,11 +1623,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = ramparts_04
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1268,11 +1640,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = ramparts_05
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1281,11 +1657,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = ramparts_06
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1294,11 +1674,15 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = ramparts_07
             building_ramparts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1307,14 +1691,18 @@ clrbnit_magic_add_ramparts_building_effect = {
             }
         }
         add_building = ramparts_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_curtain_walls_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = curtain_walls_01
@@ -1330,11 +1718,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = curtain_walls_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = curtain_walls_01
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1343,11 +1735,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = curtain_walls_02
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1356,11 +1752,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = curtain_walls_03
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1369,11 +1769,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = curtain_walls_04
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1382,11 +1786,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = curtain_walls_05
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1395,11 +1803,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = curtain_walls_06
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1408,11 +1820,15 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = curtain_walls_07
             building_curtain_walls_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1421,14 +1837,18 @@ clrbnit_magic_add_curtain_walls_building_effect = {
             }
         }
         add_building = curtain_walls_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_watchtowers_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = watchtowers_01
@@ -1444,11 +1864,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = watchtowers_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = watchtowers_01
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1457,11 +1881,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = watchtowers_02
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1470,11 +1898,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = watchtowers_03
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1483,11 +1915,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = watchtowers_04
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1496,11 +1932,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = watchtowers_05
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1509,11 +1949,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = watchtowers_06
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1522,11 +1966,15 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = watchtowers_07
             building_watchtowers_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1535,14 +1983,18 @@ clrbnit_magic_add_watchtowers_building_effect = {
             }
         }
         add_building = watchtowers_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_cereal_fields_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = cereal_fields_01
@@ -1558,11 +2010,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = cereal_fields_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = cereal_fields_01
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1571,11 +2027,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = cereal_fields_02
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1584,11 +2044,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = cereal_fields_03
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1597,11 +2061,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = cereal_fields_04
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1610,11 +2078,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = cereal_fields_05
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1623,11 +2095,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = cereal_fields_06
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1636,11 +2112,15 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = cereal_fields_07
             building_cereal_fields_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1649,14 +2129,18 @@ clrbnit_magic_add_cereal_fields_building_effect = {
             }
         }
         add_building = cereal_fields_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_outposts_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = outposts_01
@@ -1672,11 +2156,15 @@ clrbnit_magic_add_outposts_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = outposts_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = outposts_01
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1685,11 +2173,15 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = outposts_02
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1698,11 +2190,15 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = outposts_03
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1711,11 +2207,15 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = outposts_04
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1724,11 +2224,15 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = outposts_05
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1737,11 +2241,15 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = outposts_06
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1750,11 +2258,15 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = outposts_07
             building_outposts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1763,14 +2275,18 @@ clrbnit_magic_add_outposts_building_effect = {
             }
         }
         add_building = outposts_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_barracks_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = barracks_01
@@ -1786,11 +2302,15 @@ clrbnit_magic_add_barracks_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = barracks_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = barracks_01
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1799,11 +2319,15 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = barracks_02
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1812,11 +2336,15 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = barracks_03
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1825,11 +2353,15 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = barracks_04
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1838,11 +2370,15 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = barracks_05
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1851,11 +2387,15 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = barracks_06
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1864,11 +2404,15 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = barracks_07
             building_barracks_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1877,14 +2421,18 @@ clrbnit_magic_add_barracks_building_effect = {
             }
         }
         add_building = barracks_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_camel_farms_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = camel_farms_01
@@ -1900,11 +2448,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = camel_farms_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = camel_farms_01
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -1913,11 +2465,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = camel_farms_02
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1926,11 +2482,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = camel_farms_03
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -1939,11 +2499,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = camel_farms_04
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1952,11 +2516,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = camel_farms_05
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -1965,11 +2533,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = camel_farms_06
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1978,11 +2550,15 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = camel_farms_07
             building_camel_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -1991,14 +2567,18 @@ clrbnit_magic_add_camel_farms_building_effect = {
             }
         }
         add_building = camel_farms_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_logging_camps_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = logging_camps_01
@@ -2014,11 +2594,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = logging_camps_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = logging_camps_01
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2027,11 +2611,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = logging_camps_02
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2040,11 +2628,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = logging_camps_03
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2053,11 +2645,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = logging_camps_04
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2066,11 +2662,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = logging_camps_05
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2079,11 +2679,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = logging_camps_06
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2092,11 +2696,15 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = logging_camps_07
             building_logging_camps_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2105,14 +2713,18 @@ clrbnit_magic_add_logging_camps_building_effect = {
             }
         }
         add_building = logging_camps_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_peat_quarries_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = peat_quarries_01
@@ -2128,11 +2740,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = peat_quarries_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = peat_quarries_01
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2141,11 +2757,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = peat_quarries_02
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2154,11 +2774,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = peat_quarries_03
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2167,11 +2791,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = peat_quarries_04
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2180,11 +2808,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = peat_quarries_05
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2193,11 +2825,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = peat_quarries_06
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2206,11 +2842,15 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = peat_quarries_07
             building_peat_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2219,14 +2859,18 @@ clrbnit_magic_add_peat_quarries_building_effect = {
             }
         }
         add_building = peat_quarries_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_hill_farms_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = hill_farms_01
@@ -2242,11 +2886,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = hill_farms_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = hill_farms_01
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2255,11 +2903,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = hill_farms_02
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2268,11 +2920,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = hill_farms_03
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2281,11 +2937,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = hill_farms_04
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2294,11 +2954,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = hill_farms_05
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2307,11 +2971,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = hill_farms_06
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2320,11 +2988,15 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = hill_farms_07
             building_hill_farms_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2333,14 +3005,18 @@ clrbnit_magic_add_hill_farms_building_effect = {
             }
         }
         add_building = hill_farms_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_elephant_pens_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = elephant_pens_01
@@ -2356,11 +3032,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = elephant_pens_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = elephant_pens_01
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2369,11 +3049,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = elephant_pens_02
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2382,11 +3066,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = elephant_pens_03
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2395,11 +3083,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = elephant_pens_04
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2408,11 +3100,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = elephant_pens_05
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2421,11 +3117,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = elephant_pens_06
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2434,11 +3134,15 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = elephant_pens_07
             building_elephant_pens_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2447,14 +3151,18 @@ clrbnit_magic_add_elephant_pens_building_effect = {
             }
         }
         add_building = elephant_pens_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_plantations_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = plantations_01
@@ -2470,11 +3178,15 @@ clrbnit_magic_add_plantations_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = plantations_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = plantations_01
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2483,11 +3195,15 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = plantations_02
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2496,11 +3212,15 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = plantations_03
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2509,11 +3229,15 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = plantations_04
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2522,11 +3246,15 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = plantations_05
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2535,11 +3263,15 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = plantations_06
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2548,11 +3280,15 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = plantations_07
             building_plantations_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2561,14 +3297,18 @@ clrbnit_magic_add_plantations_building_effect = {
             }
         }
         add_building = plantations_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_quarries_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = quarries_01
@@ -2584,11 +3324,15 @@ clrbnit_magic_add_quarries_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = quarries_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = quarries_01
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2597,11 +3341,15 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = quarries_02
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2610,11 +3358,15 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = quarries_03
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2623,11 +3375,15 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = quarries_04
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2636,11 +3392,15 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = quarries_05
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2649,11 +3409,15 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = quarries_06
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2662,11 +3426,15 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = quarries_07
             building_quarries_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2675,14 +3443,18 @@ clrbnit_magic_add_quarries_building_effect = {
             }
         }
         add_building = quarries_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_hill_forts_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = hill_forts_01
@@ -2698,11 +3470,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = hill_forts_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = hill_forts_01
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2711,11 +3487,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = hill_forts_02
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2724,11 +3504,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = hill_forts_03
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2737,11 +3521,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = hill_forts_04
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2750,11 +3538,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = hill_forts_05
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2763,11 +3555,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = hill_forts_06
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2776,11 +3572,15 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = hill_forts_07
             building_hill_forts_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2789,14 +3589,18 @@ clrbnit_magic_add_hill_forts_building_effect = {
             }
         }
         add_building = hill_forts_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_common_tradeport_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = common_tradeport_01
@@ -2812,11 +3616,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = common_tradeport_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = common_tradeport_01
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -2825,11 +3633,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = common_tradeport_02
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2838,11 +3650,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = common_tradeport_03
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -2851,11 +3667,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = common_tradeport_04
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2864,11 +3684,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = common_tradeport_05
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -2877,11 +3701,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = common_tradeport_06
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2890,11 +3718,15 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = common_tradeport_07
             building_common_tradeport_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -2903,14 +3735,18 @@ clrbnit_magic_add_common_tradeport_building_effect = {
             }
         }
         add_building = common_tradeport_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_guild_halls_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             has_holding_type = city_holding
             NOT = {
@@ -2926,11 +3762,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             has_building_or_higher = city_01         
         }
         add_building = guild_halls_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = guild_halls_01
             has_building_or_higher = city_01
             prev.culture = {
@@ -2938,11 +3778,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = guild_halls_02
             has_building_or_higher = city_02
             prev.culture = {
@@ -2950,11 +3794,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = guild_halls_03
             has_building_or_higher = city_02
             prev.culture = {
@@ -2962,11 +3810,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = guild_halls_04
             has_building_or_higher = city_03
             prev.culture = {
@@ -2974,11 +3826,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = guild_halls_05
             has_building_or_higher = city_03
             prev.culture = {
@@ -2986,11 +3842,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = guild_halls_06
             has_building_or_higher = city_04
             prev.culture = {
@@ -2998,11 +3858,15 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = guild_halls_07
             has_building_or_higher = city_04
             prev.culture = {
@@ -3010,14 +3874,18 @@ clrbnit_magic_add_guild_halls_building_effect = {
             }
         }
         add_building = guild_halls_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
 clrbnit_magic_add_castle_building_effect = {
     if = {
         limit = {
-            prev = {gold > main_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_2_cost
+                }}
             has_holding_type = castle_holding
             has_building = castle_01
             prev.culture = {
@@ -3025,11 +3893,15 @@ clrbnit_magic_add_castle_building_effect = {
             }   
         }
         add_building = castle_02
-        prev = {remove_short_term_gold = main_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > main_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_3_cost
+                }}
             has_holding_type = castle_holding
             has_building = castle_02
             prev.culture = {
@@ -3037,11 +3909,15 @@ clrbnit_magic_add_castle_building_effect = {
             }
         }   
         add_building = castle_03
-        prev = {remove_short_term_gold = main_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > main_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_4_cost
+                }}
             has_holding_type = castle_holding
             has_building = castle_03
             prev.culture = {
@@ -3049,14 +3925,18 @@ clrbnit_magic_add_castle_building_effect = {
             }  
         } 
         add_building = castle_04
-        prev = {remove_short_term_gold = main_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_4_cost}
     }
 }
 
 clrbnit_magic_add_city_building_effect = {
     if = {
         limit = {
-            prev = {gold > main_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_2_cost
+                }}
             has_holding_type = city_holding
             has_building = city_01
             prev.culture = {
@@ -3064,11 +3944,15 @@ clrbnit_magic_add_city_building_effect = {
             }   
         }
         add_building = city_02
-        prev = {remove_short_term_gold = main_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > main_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_3_cost
+                }}
             has_holding_type = city_holding
             has_building = city_02
             prev.culture = {
@@ -3076,11 +3960,15 @@ clrbnit_magic_add_city_building_effect = {
             }   
         }
         add_building = city_03
-        prev = {remove_short_term_gold = main_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > main_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_4_cost
+                }}
             has_holding_type = city_holding
             has_building = city_03
             prev.culture = {
@@ -3088,14 +3976,18 @@ clrbnit_magic_add_city_building_effect = {
             }  
         } 
         add_building = city_04
-        prev = {remove_short_term_gold = main_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_4_cost}
     }
 }
 
 clrbnit_magic_add_temple_building_effect = {
     if = {
         limit = {
-            prev = {gold > main_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_2_cost
+                }}
             has_holding_type = church_holding
             has_building = temple_01
             prev.culture = {
@@ -3103,11 +3995,15 @@ clrbnit_magic_add_temple_building_effect = {
             }   
         }
         add_building = temple_02
-        prev = {remove_short_term_gold = main_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > main_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_3_cost
+                }}
             has_holding_type = church_holding
             has_building = temple_02
             prev.culture = {
@@ -3115,11 +4011,15 @@ clrbnit_magic_add_temple_building_effect = {
             } 
         }  
         add_building = temple_03
-        prev = {remove_short_term_gold = main_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > main_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = main_building_tier_4_cost
+                }}
             has_holding_type = church_holding
             has_building = temple_03
             prev.culture = {
@@ -3127,14 +4027,18 @@ clrbnit_magic_add_temple_building_effect = {
             } 
         }  
         add_building = temple_04
-        prev = {remove_short_term_gold = main_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = main_building_tier_4_cost}
     }
 }
 
 clrbnit_magic_add_monastic_schools_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = monastic_schools_01
@@ -3149,11 +4053,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             has_building_or_higher = temple_01
         }
         add_building = monastic_schools_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = monastic_schools_01
             has_building_or_higher = temple_01
             prev.culture = {
@@ -3161,11 +4069,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = monastic_schools_02
             has_building_or_higher = temple_02
             prev.culture = {
@@ -3173,11 +4085,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = monastic_schools_03
             has_building_or_higher = temple_02
             prev.culture = {
@@ -3185,11 +4101,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = monastic_schools_04
             has_building_or_higher = temple_03
             prev.culture = {
@@ -3197,11 +4117,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = monastic_schools_05
             has_building_or_higher = temple_03
             prev.culture = {
@@ -3209,11 +4133,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = monastic_schools_06
             has_building_or_higher = temple_04
             prev.culture = {
@@ -3221,11 +4149,15 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = monastic_schools_07
             has_building_or_higher = temple_04
             prev.culture = {
@@ -3233,7 +4165,7 @@ clrbnit_magic_add_monastic_schools_building_effect = {
             }
         }
         add_building = monastic_schools_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -3241,7 +4173,11 @@ clrbnit_magic_add_monastic_schools_building_effect = {
 clrbnit_magic_add_windmills_building_effect = {
     if = {
         limit = {
-            prev = { gold > normal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = windmills_01
@@ -3289,91 +4225,123 @@ clrbnit_magic_add_windmills_building_effect = {
             }
         }
         add_building = windmills_01
-        prev = { remove_short_term_gold = normal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost }
+            }
             has_building = windmills_01
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
             prev.culture = { has_innovation = innovation_crop_rotation }
         }
         add_building = windmills_02
-        prev = { remove_short_term_gold = normal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_2_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost }
+            }
             has_building = windmills_02
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
             prev.culture = { has_innovation = innovation_manorialism }
         }
         add_building = windmills_03
-        prev = { remove_short_term_gold = normal_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_3_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost }
+            }
             has_building = windmills_03
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
             prev.culture = { has_innovation = innovation_manorialism }
         }
         add_building = windmills_04
-        prev = { remove_short_term_gold = normal_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_4_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_5_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost }
+            }
             has_building = windmills_04
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
             prev.culture = { has_innovation = innovation_windmills }
         }
         add_building = windmills_05
-        prev = { remove_short_term_gold = normal_building_tier_5_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_5_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_6_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost }
+            }
             has_building = windmills_05
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
             prev.culture = { has_innovation = innovation_windmills }
         }
         add_building = windmills_06
-        prev = { remove_short_term_gold = normal_building_tier_6_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_6_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_7_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost }
+            }
             has_building = windmills_06
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
             prev.culture = { has_innovation = innovation_cranes }
         }
         add_building = windmills_07
-        prev = { remove_short_term_gold = normal_building_tier_7_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_7_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_8_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost }
+            }
             has_building = windmills_07
             building_windmills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
             prev.culture = { has_innovation = innovation_cranes }
         }
         add_building = windmills_08
-        prev = { remove_short_term_gold = normal_building_tier_8_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_8_cost }
     }
 }
 
 clrbnit_magic_add_watermills_building_effect = {
     if = {
         limit = {
-            prev = { gold > normal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = watermills_01
@@ -3421,84 +4389,112 @@ clrbnit_magic_add_watermills_building_effect = {
             }
         }
         add_building = watermills_01
-        prev = { remove_short_term_gold = normal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost }
+            }
             has_building = watermills_01
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
             prev.culture = { has_innovation = innovation_crop_rotation }
         }
         add_building = watermills_02
-        prev = { remove_short_term_gold = normal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_2_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost }
+            }
             has_building = watermills_02
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
             prev.culture = { has_innovation = innovation_manorialism }
         }
         add_building = watermills_03
-        prev = { remove_short_term_gold = normal_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_3_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost }
+            }
             has_building = watermills_03
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
             prev.culture = { has_innovation = innovation_manorialism }
         }
         add_building = watermills_04
-        prev = { remove_short_term_gold = normal_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_4_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_5_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost }
+            }
             has_building = watermills_04
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
             prev.culture = { has_innovation = innovation_windmills }
         }
         add_building = watermills_05
-        prev = { remove_short_term_gold = normal_building_tier_5_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_5_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_6_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost }
+            }
             has_building = watermills_05
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
             prev.culture = { has_innovation = innovation_windmills }
         }
         add_building = watermills_06
-        prev = { remove_short_term_gold = normal_building_tier_6_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_6_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_7_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost }
+            }
             has_building = watermills_06
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
             prev.culture = { has_innovation = innovation_cranes }
         }
         add_building = watermills_07
-        prev = { remove_short_term_gold = normal_building_tier_7_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_7_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > normal_building_tier_8_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost }
+            }
             has_building = watermills_07
             building_watermills_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
             prev.culture = { has_innovation = innovation_cranes }
         }
         add_building = watermills_08
-        prev = { remove_short_term_gold = normal_building_tier_8_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_8_cost }
     }
 }
 
@@ -3506,7 +4502,11 @@ clrbnit_magic_add_watermills_building_effect = {
 clrbnit_magic_add_caravanserai_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = caravanserai_01
@@ -3522,11 +4522,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = caravanserai_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = caravanserai_01
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -3535,11 +4539,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = caravanserai_02
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3548,11 +4556,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = caravanserai_03
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3561,11 +4573,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = caravanserai_04
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3574,11 +4590,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = caravanserai_05
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3587,11 +4607,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = caravanserai_06
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3600,11 +4624,15 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = caravanserai_07
             building_caravanserai_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3613,7 +4641,7 @@ clrbnit_magic_add_caravanserai_building_effect = {
             }
         }
         add_building = caravanserai_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -3621,7 +4649,11 @@ clrbnit_magic_add_caravanserai_building_effect = {
 clrbnit_magic_add_wind_furnace_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = wind_furnace_01
@@ -3637,11 +4669,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = wind_furnace_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = wind_furnace_01
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -3650,11 +4686,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = wind_furnace_02
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3663,11 +4703,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = wind_furnace_03
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3676,11 +4720,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = wind_furnace_04
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3689,11 +4737,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = wind_furnace_05
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3702,11 +4754,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = wind_furnace_06
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3715,11 +4771,15 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = wind_furnace_07
             building_wind_furnace_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3728,7 +4788,7 @@ clrbnit_magic_add_wind_furnace_building_effect = {
             }
         }
         add_building = wind_furnace_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -3736,7 +4796,11 @@ clrbnit_magic_add_wind_furnace_building_effect = {
 clrbnit_magic_add_smiths_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = smiths_01
@@ -3752,11 +4816,15 @@ clrbnit_magic_add_smiths_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = smiths_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = smiths_01
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -3764,11 +4832,15 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = smiths_02
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3776,11 +4848,15 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = smiths_03
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3788,11 +4864,15 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = smiths_04
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3800,11 +4880,15 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = smiths_05
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3812,11 +4896,15 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = smiths_06
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3824,11 +4912,15 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = smiths_07
             building_smiths_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3836,7 +4928,7 @@ clrbnit_magic_add_smiths_building_effect = {
             }
         }
         add_building = smiths_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -3844,7 +4936,11 @@ clrbnit_magic_add_smiths_building_effect = {
 clrbnit_magic_add_workshops_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = workshops_01
@@ -3860,11 +4956,15 @@ clrbnit_magic_add_workshops_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = workshops_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = workshops_01
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -3873,11 +4973,15 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = workshops_02
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3886,11 +4990,15 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = workshops_03
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -3899,11 +5007,15 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = workshops_04
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3912,11 +5024,15 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = workshops_05
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -3925,11 +5041,15 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = workshops_06
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3938,11 +5058,15 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = workshops_07
             building_workshops_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -3951,7 +5075,7 @@ clrbnit_magic_add_workshops_building_effect = {
             }
         }
         add_building = workshops_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -3959,7 +5083,11 @@ clrbnit_magic_add_workshops_building_effect = {
 clrbnit_magic_add_stables_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = stables_01
@@ -3975,11 +5103,15 @@ clrbnit_magic_add_stables_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = stables_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = stables_01
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -3988,11 +5120,15 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = stables_02
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4001,11 +5137,15 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = stables_03
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4014,11 +5154,15 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = stables_04
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4027,11 +5171,15 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = stables_05
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4040,11 +5188,15 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = stables_06
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4053,11 +5205,15 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = stables_07
             building_stables_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4066,7 +5222,7 @@ clrbnit_magic_add_stables_building_effect = {
             }
         }
         add_building = stables_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -4074,7 +5230,11 @@ clrbnit_magic_add_stables_building_effect = {
 clrbnit_magic_add_horse_pastures_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = horse_pastures_01
@@ -4090,11 +5250,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = horse_pastures_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = horse_pastures_01
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -4103,11 +5267,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = horse_pastures_02
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4116,11 +5284,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = horse_pastures_03
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4129,11 +5301,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = horse_pastures_04
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4142,11 +5318,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = horse_pastures_05
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4155,11 +5335,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = horse_pastures_06
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4168,11 +5352,15 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = horse_pastures_07
             building_horse_pastures_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4181,7 +5369,7 @@ clrbnit_magic_add_horse_pastures_building_effect = {
             }
         }
         add_building = horse_pastures_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }
 
@@ -4189,7 +5377,11 @@ clrbnit_magic_add_horse_pastures_building_effect = {
 clrbnit_magic_add_warrior_lodges_building_effect = {
     if = {
         limit = {
-            prev = {gold > normal_building_tier_1_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
             has_free_building_slot = yes
             NOT = {
                 has_building = warrior_lodges_01
@@ -4205,11 +5397,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }         
         }
         add_building = warrior_lodges_01
-        prev = {remove_short_term_gold = normal_building_tier_1_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_1_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_2_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
             has_building = warrior_lodges_01
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
@@ -4218,11 +5414,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_02
-        prev = {remove_short_term_gold = normal_building_tier_2_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_2_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_3_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
             has_building = warrior_lodges_02
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4231,11 +5431,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_03
-        prev = {remove_short_term_gold = normal_building_tier_3_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_3_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_4_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
             has_building = warrior_lodges_03
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4244,11 +5448,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_04
-        prev = {remove_short_term_gold = normal_building_tier_4_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_4_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_5_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
             has_building = warrior_lodges_04
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4257,11 +5465,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_05
-        prev = {remove_short_term_gold = normal_building_tier_5_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_5_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_6_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
             has_building = warrior_lodges_05
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4270,11 +5482,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_06
-        prev = {remove_short_term_gold = normal_building_tier_6_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_6_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_7_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
             has_building = warrior_lodges_06
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4283,11 +5499,15 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_07
-        prev = {remove_short_term_gold = normal_building_tier_7_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_7_cost}
     }
     else_if = {
         limit = {
-            prev = {gold > normal_building_tier_8_cost}
+            prev = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
             has_building = warrior_lodges_07
             building_warrior_lodges_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4296,12 +5516,16 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = warrior_lodges_08
-        prev = {remove_short_term_gold = normal_building_tier_8_cost}
+        prev = {remove_treasury_or_gold = normal_building_tier_8_cost}
     }
 }add_walls_building_effect = {
     if = {
         limit = {
-            prev = { gold > cheap_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = walls_01
@@ -4311,37 +5535,53 @@ clrbnit_magic_add_warrior_lodges_building_effect = {
             }
         }
         add_building = walls_01
-        prev = { remove_short_term_gold = cheap_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_2_cost }
+            }
             has_building = walls_01
         }
         add_building = walls_02
-        prev = { remove_short_term_gold = cheap_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_2_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_3_cost }
+            }
             has_building = walls_02
         }
         add_building = walls_03
-        prev = { remove_short_term_gold = cheap_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_3_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > cheap_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = cheap_building_tier_4_cost }
+            }
             has_building = walls_03
         }
         add_building = walls_04
-        prev = { remove_short_term_gold = cheap_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = cheap_building_tier_4_cost }
     }
 }
 clrbnit_magic_add_longhouses_building_effect = {
     if = {
         limit = {
-            prev = { gold > tribal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = longhouses_01
@@ -4350,11 +5590,15 @@ clrbnit_magic_add_longhouses_building_effect = {
             building_requirement_tribal = yes
         }
         add_building = longhouses_01
-        prev = { remove_short_term_gold = tribal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > tribal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_2_cost }
+            }
             has_building = longhouses_01
             building_requirement_tribal = yes
             OR = {
@@ -4363,14 +5607,18 @@ clrbnit_magic_add_longhouses_building_effect = {
             }
         }
         add_building = longhouses_02
-        prev = { remove_short_term_gold = tribal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_2_cost }
     }
 }
 
 clrbnit_magic_add_war_camps_building_effect = {
     if = {
         limit = {
-            prev = { gold > tribal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = war_camps_01
@@ -4379,11 +5627,15 @@ clrbnit_magic_add_war_camps_building_effect = {
             building_requirement_tribal = yes
         }
         add_building = war_camps_01
-        prev = { remove_short_term_gold = tribal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > tribal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_2_cost }
+            }
             has_building = war_camps_01
             building_requirement_tribal = yes
             OR = {
@@ -4392,14 +5644,18 @@ clrbnit_magic_add_war_camps_building_effect = {
             }
         }
         add_building = war_camps_02
-        prev = { remove_short_term_gold = tribal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_2_cost }
     }
 }
 
 clrbnit_magic_add_palisades_building_effect = {
     if = {
         limit = {
-            prev = { gold > tribal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = palisades_01
@@ -4408,11 +5664,15 @@ clrbnit_magic_add_palisades_building_effect = {
             building_requirement_tribal = yes
         }
         add_building = palisades_01
-        prev = { remove_short_term_gold = tribal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > tribal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_2_cost }
+            }
             has_building = palisades_01
             building_requirement_tribal = yes
             OR = {
@@ -4421,14 +5681,18 @@ clrbnit_magic_add_palisades_building_effect = {
             }
         }
         add_building = palisades_02
-        prev = { remove_short_term_gold = tribal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_2_cost }
     }
 }
 
 clrbnit_magic_add_market_villages_building_effect = {
     if = {
         limit = {
-            prev = { gold > tribal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = market_villages_01
@@ -4437,11 +5701,15 @@ clrbnit_magic_add_market_villages_building_effect = {
             building_requirement_tribal = yes
         }
         add_building = market_villages_01
-        prev = { remove_short_term_gold = tribal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_1_cost }
     }
     else_if = {
         limit = {
-            prev = { gold > tribal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = tribal_building_tier_2_cost }
+            }
             has_building = market_villages_01
             building_requirement_tribal = yes
             OR = {
@@ -4450,14 +5718,18 @@ clrbnit_magic_add_market_villages_building_effect = {
             }
         }
         add_building = market_villages_02
-        prev = { remove_short_term_gold = tribal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = tribal_building_tier_2_cost }
     }
 }
 
 clrbnit_magic_add_scriptorium_building_effect = {
     if = {
         limit = {
-            prev = { gold > normal_building_tier_1_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost }
+            }
             has_free_building_slot = yes
             NOT = {
                 has_building = scriptorium_01
@@ -4473,21 +5745,29 @@ clrbnit_magic_add_scriptorium_building_effect = {
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = scriptorium_01
-        prev = { remove_short_term_gold = normal_building_tier_1_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_1_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_2_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost }
+            }
             has_building = scriptorium_01
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 01 }
         }
         add_building = scriptorium_02
-        prev = { remove_short_term_gold = normal_building_tier_2_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_2_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_3_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost }
+            }
             has_building = scriptorium_02
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4496,11 +5776,15 @@ clrbnit_magic_add_scriptorium_building_effect = {
             }
         }
         add_building = scriptorium_03
-        prev = { remove_short_term_gold = normal_building_tier_3_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_3_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_4_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost }
+            }
             has_building = scriptorium_03
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 02 }
@@ -4509,11 +5793,15 @@ clrbnit_magic_add_scriptorium_building_effect = {
             }
         }
         add_building = scriptorium_04
-        prev = { remove_short_term_gold = normal_building_tier_4_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_4_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_5_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost }
+            }
             has_building = scriptorium_04
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4522,11 +5810,15 @@ clrbnit_magic_add_scriptorium_building_effect = {
             }
         }
         add_building = scriptorium_05
-        prev = { remove_short_term_gold = normal_building_tier_5_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_5_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_6_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost }
+            }
             has_building = scriptorium_05
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 03 }
@@ -4535,11 +5827,15 @@ clrbnit_magic_add_scriptorium_building_effect = {
             }
         }
         add_building = scriptorium_06
-        prev = { remove_short_term_gold = normal_building_tier_6_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_6_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_7_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost }
+            }
             has_building = scriptorium_06
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4548,11 +5844,15 @@ clrbnit_magic_add_scriptorium_building_effect = {
             }
         }
         add_building = scriptorium_07
-        prev = { remove_short_term_gold = normal_building_tier_7_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_7_cost }
     }
     if = {
         limit = {
-            prev = { gold > normal_building_tier_8_cost }
+            prev = { 
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost }
+            }
             has_building = scriptorium_07
             clrbnit_magic_building_scriptorium_requirement_terrain = yes
             building_requirement_castle_city_church = { LEVEL = 04 }
@@ -4561,7 +5861,7 @@ clrbnit_magic_add_scriptorium_building_effect = {
             }
         }
         add_building = scriptorium_08
-        prev = { remove_short_term_gold = normal_building_tier_8_cost }
+        prev = { remove_treasury_or_gold = normal_building_tier_8_cost }
     }
 }
 # Capital Bureau auto-upgrade (province-scope safe)
@@ -4579,9 +5879,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 01 }
-            province_owner = { gold > normal_building_tier_1_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_1_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_1_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_1_cost }
         add_building = capital_bureau_01
     }
     # Tier 2
@@ -4596,9 +5900,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 01 }
-            province_owner = { gold > normal_building_tier_2_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_2_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_2_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_2_cost }
         add_building = capital_bureau_02
     }
     # Tier 3
@@ -4612,9 +5920,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 02 }
-            province_owner = { gold > normal_building_tier_3_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_3_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_3_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_3_cost }
         add_building = capital_bureau_03
     }
     # Tier 4
@@ -4627,9 +5939,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 02 }
-            province_owner = { gold > normal_building_tier_4_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_4_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_4_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_4_cost }
         add_building = capital_bureau_04
     }
     # Tier 5
@@ -4641,9 +5957,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 03 }
-            province_owner = { gold > normal_building_tier_5_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_5_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_5_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_5_cost }
         add_building = capital_bureau_05
     }
     # Tier 6
@@ -4654,9 +5974,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 03 }
-            province_owner = { gold > normal_building_tier_6_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_6_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_6_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_6_cost }
         add_building = capital_bureau_06
     }
     # Tier 7
@@ -4666,9 +5990,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             NOT = { has_building = capital_bureau_07 }
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 04 }
-            province_owner = { gold > normal_building_tier_7_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_7_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_7_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_7_cost }
         add_building = capital_bureau_07
     }
     # Tier 8
@@ -4677,9 +6005,13 @@ clrbnit_magic_add_capital_bureau_building_effect = {
             has_building = capital_bureau_07
             NOT = { has_building = capital_bureau_08 }
             building_requirement_castle_city_church = { LEVEL = 04 }
-            province_owner = { gold > normal_building_tier_8_cost }
+            province_owner = {
+                treasury_or_gold > {
+                    value = var:spending_limit
+                    add = normal_building_tier_8_cost
+                }}
         }
-        province_owner = { remove_short_term_gold = normal_building_tier_8_cost }
+        province_owner = { remove_treasury_or_gold = normal_building_tier_8_cost }
         add_building = capital_bureau_08
     }
 }

--- a/common/scripted_effects/spending_effects.txt
+++ b/common/scripted_effects/spending_effects.txt
@@ -1,0 +1,27 @@
+﻿# Flags for spending limits
+
+# Effect to clear all spending limit status flags.
+clear_spending_limit_flags = {
+    remove_character_flag = limit_active_tiny
+    remove_character_flag = limit_active_minor
+    remove_character_flag = limit_active_medium
+    remove_character_flag = limit_active_major
+    remove_character_flag = limit_active_massive
+    remove_character_flag = limit_active_monumental
+}
+
+# Effect to initialize the spending limit variable to the default if not set yet
+initialize_spending_limit_default = {
+    if = {
+        limit = { NOT = { has_variable = spending_limit } }
+        
+        clear_spending_limit_flags = yes
+        
+        set_variable = { 
+            name = spending_limit 
+            value = monumental_gold_value 
+        }
+        
+        add_character_flag = limit_active_monumental
+    }
+}

--- a/common/scripted_effects/spending_effects.txt
+++ b/common/scripted_effects/spending_effects.txt
@@ -1,6 +1,4 @@
-﻿# Flags for spending limits
-
-# Effect to clear all spending limit status flags.
+﻿# Effect to clear all spending limit status flags.
 clear_spending_limit_flags = {
     remove_character_flag = limit_active_tiny
     remove_character_flag = limit_active_minor
@@ -8,20 +6,4 @@ clear_spending_limit_flags = {
     remove_character_flag = limit_active_major
     remove_character_flag = limit_active_massive
     remove_character_flag = limit_active_monumental
-}
-
-# Effect to initialize the spending limit variable to the default if not set yet
-initialize_spending_limit_default = {
-    if = {
-        limit = { NOT = { has_variable = spending_limit } }
-        
-        clear_spending_limit_flags = yes
-        
-        set_variable = { 
-            name = spending_limit 
-            value = monumental_gold_value 
-        }
-        
-        add_character_flag = limit_active_monumental
-    }
 }

--- a/events/magic_build_manager.txt
+++ b/events/magic_build_manager.txt
@@ -59,11 +59,7 @@ magical_manager.0001 = {
     }
     # Set Spending Limits Menu
     option = {
-        name = magic_build_manager.0001.set_spending
-        
-        # Initialize default spending limit and flag if needed
-        initialize_spending_limit_default = yes
-        
+        name = magic_build_manager.0001.set_spending        
         trigger_event = magical_manager.0002
     }
 
@@ -87,110 +83,103 @@ magical_manager.0002 = {
     desc = magic_build_manager.0002.desc
     left_portrait = root
     
-    # Active version
+    # Tiny Limit Option
     option = {
-        name = magic_build_manager.0002.tiny_limit_active
-        trigger = { has_character_flag = limit_active_tiny }
-        trigger_event = magical_manager.0001 
-    }
-
-    # Inactive version
-    option = {
-        name = magic_build_manager.0002.tiny_limit_inactive
+        name = magic_build_manager.0002.tiny_limit
         trigger = { NOT = { has_character_flag = limit_active_tiny } }
+        show_as_unavailable = { has_character_flag = limit_active_tiny }
         
         clear_spending_limit_flags = yes
         set_variable = { name = spending_limit value = tiny_gold_value }
         add_character_flag = limit_active_tiny
         
-        trigger_event = magical_manager.0001
+        trigger_event = magical_manager.0002
     }
     
+    # Minor Limit Option
     option = {
-        name = magic_build_manager.0002.minor_limit_active
-        trigger = { has_character_flag = limit_active_minor }
-        trigger_event = magical_manager.0001
-    }
-
-    option = {
-        name = magic_build_manager.0002.minor_limit_inactive
+        name = magic_build_manager.0002.minor_limit
         trigger = { NOT = { has_character_flag = limit_active_minor } }
+        show_as_unavailable = { has_character_flag = limit_active_minor }
         
         clear_spending_limit_flags = yes
         set_variable = { name = spending_limit value = minor_gold_value }
         add_character_flag = limit_active_minor
         
-        trigger_event = magical_manager.0001
+        trigger_event = magical_manager.0002
     }
     
+    # Medium Limit Option
     option = {
-        name = magic_build_manager.0002.medium_limit_active
-        trigger = { has_character_flag = limit_active_medium }
-        trigger_event = magical_manager.0001
-    }
-
-    option = {
-        name = magic_build_manager.0002.medium_limit_inactive
+        name = magic_build_manager.0002.medium_limit
         trigger = { NOT = { has_character_flag = limit_active_medium } }
+        show_as_unavailable = { has_character_flag = limit_active_medium }
         
         clear_spending_limit_flags = yes
         set_variable = { name = spending_limit value = medium_gold_value }
         add_character_flag = limit_active_medium
         
-        trigger_event = magical_manager.0001
+        trigger_event = magical_manager.0002
     }
     
+    # Major Limit Option
     option = {
-        name = magic_build_manager.0002.major_limit_active
-        trigger = { has_character_flag = limit_active_major }
-        trigger_event = magical_manager.0001
-    }
-
-    option = {
-        name = magic_build_manager.0002.major_limit_inactive
+        name = magic_build_manager.0002.major_limit
         trigger = { NOT = { has_character_flag = limit_active_major } }
+        show_as_unavailable = { has_character_flag = limit_active_major }
         
         clear_spending_limit_flags = yes
         set_variable = { name = spending_limit value = major_gold_value }
         add_character_flag = limit_active_major
         
-        trigger_event = magical_manager.0001
+        trigger_event = magical_manager.0002
     }
     
+    # Massive Limit Option
     option = {
-        name = magic_build_manager.0002.massive_limit_active
-        trigger = { has_character_flag = limit_active_massive }
-        trigger_event = magical_manager.0001
-    }
-
-    option = {
-        name = magic_build_manager.0002.massive_limit_inactive
+        name = magic_build_manager.0002.massive_limit
         trigger = { NOT = { has_character_flag = limit_active_massive } }
+        show_as_unavailable = { has_character_flag = limit_active_massive }
         
         clear_spending_limit_flags = yes
         set_variable = { name = spending_limit value = massive_gold_value }
         add_character_flag = limit_active_massive
         
-        trigger_event = magical_manager.0001
+        trigger_event = magical_manager.0002
     }
 
+    # Monumental Limit Option
     option = {
-        name = magic_build_manager.0002.monumental_limit_active
-        trigger = { has_character_flag = limit_active_monumental }
-        trigger_event = magical_manager.0001 
-    }
- 
-    option = {
-        name = magic_build_manager.0002.monumental_limit_inactive
+        name = magic_build_manager.0002.monumental_limit
         trigger = { NOT = { has_character_flag = limit_active_monumental } }
+        show_as_unavailable = { has_character_flag = limit_active_monumental }
         
         clear_spending_limit_flags = yes
         set_variable = { name = spending_limit value = monumental_gold_value }
         add_character_flag = limit_active_monumental
         
-        trigger_event = magical_manager.0001 
+        trigger_event = magical_manager.0002 
     }
     
+    # Clear Limit Option (Only visible/valid if a limit is currently active)
+    option = {
+        name = magic_build_manager.0002.clear_limit
+        trigger = { 
+            OR = {
+                has_character_flag = limit_active_tiny
+                has_character_flag = limit_active_minor
+                has_character_flag = limit_active_medium
+                has_character_flag = limit_active_major
+                has_character_flag = limit_active_massive
+                has_character_flag = limit_active_monumental
+            }
+        }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = 0 }
+        trigger_event = magical_manager.0002 
+    }
+
     # Return Button
     option = {
         name = magic_build_manager.0002.back
@@ -202,7 +191,7 @@ magical_manager.0002 = {
 magical_manager.9999 = {
     type = character_event
     override_background = { reference = magical_throneroom }
-    title = magic_build_manager.9999.t
+    title = magic_build_mer.9999.t
     desc = magic_build_manager.9999.desc
     theme = stewardship_domain_focus
 

--- a/events/magic_build_manager.txt
+++ b/events/magic_build_manager.txt
@@ -57,8 +57,17 @@ magical_manager.0001 = {
         remove_character_flag = enable_magic_estates
         trigger_event = clrbnit_magic.0003
     }
+    # Set Spending Limits Menu
+    option = {
+        name = magic_build_manager.0001.set_spending
+        
+        # Initialize default spending limit and flag if needed
+        initialize_spending_limit_default = yes
+        
+        trigger_event = magical_manager.0002
+    }
 
-    # About
+    # About / Credits
     option = {
         name = magic_build_manager.0001.about
         trigger_event = magical_manager.9999
@@ -70,6 +79,126 @@ magical_manager.0001 = {
     }
 }
 
+# Setting Spending Limits
+magical_manager.0002 = {
+    type = character_event
+    override_background = { reference = magical_throneroom }
+    title = magic_build_manager.0002.t
+    desc = magic_build_manager.0002.desc
+    left_portrait = root
+    
+    # Active version
+    option = {
+        name = magic_build_manager.0002.tiny_limit_active
+        trigger = { has_character_flag = limit_active_tiny }
+        trigger_event = magical_manager.0001 
+    }
+
+    # Inactive version
+    option = {
+        name = magic_build_manager.0002.tiny_limit_inactive
+        trigger = { NOT = { has_character_flag = limit_active_tiny } }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = tiny_gold_value }
+        add_character_flag = limit_active_tiny
+        
+        trigger_event = magical_manager.0001
+    }
+    
+    option = {
+        name = magic_build_manager.0002.minor_limit_active
+        trigger = { has_character_flag = limit_active_minor }
+        trigger_event = magical_manager.0001
+    }
+
+    option = {
+        name = magic_build_manager.0002.minor_limit_inactive
+        trigger = { NOT = { has_character_flag = limit_active_minor } }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = minor_gold_value }
+        add_character_flag = limit_active_minor
+        
+        trigger_event = magical_manager.0001
+    }
+    
+    option = {
+        name = magic_build_manager.0002.medium_limit_active
+        trigger = { has_character_flag = limit_active_medium }
+        trigger_event = magical_manager.0001
+    }
+
+    option = {
+        name = magic_build_manager.0002.medium_limit_inactive
+        trigger = { NOT = { has_character_flag = limit_active_medium } }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = medium_gold_value }
+        add_character_flag = limit_active_medium
+        
+        trigger_event = magical_manager.0001
+    }
+    
+    option = {
+        name = magic_build_manager.0002.major_limit_active
+        trigger = { has_character_flag = limit_active_major }
+        trigger_event = magical_manager.0001
+    }
+
+    option = {
+        name = magic_build_manager.0002.major_limit_inactive
+        trigger = { NOT = { has_character_flag = limit_active_major } }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = major_gold_value }
+        add_character_flag = limit_active_major
+        
+        trigger_event = magical_manager.0001
+    }
+    
+    option = {
+        name = magic_build_manager.0002.massive_limit_active
+        trigger = { has_character_flag = limit_active_massive }
+        trigger_event = magical_manager.0001
+    }
+
+    option = {
+        name = magic_build_manager.0002.massive_limit_inactive
+        trigger = { NOT = { has_character_flag = limit_active_massive } }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = massive_gold_value }
+        add_character_flag = limit_active_massive
+        
+        trigger_event = magical_manager.0001
+    }
+
+    option = {
+        name = magic_build_manager.0002.monumental_limit_active
+        trigger = { has_character_flag = limit_active_monumental }
+        trigger_event = magical_manager.0001 
+    }
+ 
+    option = {
+        name = magic_build_manager.0002.monumental_limit_inactive
+        trigger = { NOT = { has_character_flag = limit_active_monumental } }
+        
+        clear_spending_limit_flags = yes
+        set_variable = { name = spending_limit value = monumental_gold_value }
+        add_character_flag = limit_active_monumental
+        
+        trigger_event = magical_manager.0001 
+    }
+    
+    # Return Button
+    option = {
+        name = magic_build_manager.0002.back
+        trigger_event = magical_manager.0001
+    }
+}
+
+# Credits Event
 magical_manager.9999 = {
     type = character_event
     override_background = { reference = magical_throneroom }
@@ -81,7 +210,7 @@ magical_manager.9999 = {
         name = magic_build_manager.9999.back
         trigger_event = magical_manager.0001
     }
-
+    
     option = {
         name = magic_build_manager.9999.exit
     }

--- a/localization/english/magic_manager_l_english.yml
+++ b/localization/english/magic_manager_l_english.yml
@@ -42,25 +42,17 @@
  magic_build_manager.0001.set_spending:0 "Configure Gold Reserve Limit"
 
  # Set Spending Limit
- magic_build_manager.0002.t:0 "Configure Magic Build Gold Reserve"
+ magic_build_manager.0002.t:0 "Configure Magic Build Gold Reserve" 
  magic_build_manager.0002.desc:0 "This feature allows you to set a minimum threshold for your gold reserves (either personal gold or the Imperial Treasury). The Magic Build system will automatically block construction if the cost would reduce your available funds below this reserved amount. This is a safety margin to prevent accidental bankruptcy."
  magic_build_manager.0002.back:0 "Back"
 
- # ACTIVE (Greyed Out/Selected)
- magic_build_manager.0002.tiny_limit_active:0 "50 Reserve (Selected)!"
- magic_build_manager.0002.minor_limit_active:0 "150 Reserve (Selected)!"
- magic_build_manager.0002.medium_limit_active:0 "300 Reserve (Selected)!"
- magic_build_manager.0002.major_limit_active:0 "500 Reserve (Selected)!"
- magic_build_manager.0002.massive_limit_active:0 "750 Reserve (Selected)!"
- magic_build_manager.0002.monumental_limit_active:0 "1,500 Reserve (Selected)!"
-
- # INACTIVE (Yellow/Clickable)
- magic_build_manager.0002.tiny_limit_inactive:0 "Tiny Reserve: Keep 50 reserved"
- magic_build_manager.0002.minor_limit_inactive:0 "Minor Reserve: Keep 150 reserved"
- magic_build_manager.0002.medium_limit_inactive:0 "Medium Reserve: Keep 300 reserved"
- magic_build_manager.0002.major_limit_inactive:0 "Major Reserve: Keep 500 reserved"
- magic_build_manager.0002.massive_limit_inactive:0 "Massive Reserve: Keep 750 reserved"
- magic_build_manager.0002.monumental_limit_inactive:0 "Monumental Reserve (Default): Keep 1,500 reserved"
+ magic_build_manager.0002.tiny_limit:0 "Set Tiny Limit"
+ magic_build_manager.0002.minor_limit:0 "Set Minor Limit"
+ magic_build_manager.0002.medium_limit:0 "Set Medium Limit"
+ magic_build_manager.0002.major_limit:0 "Set Major Limit"
+ magic_build_manager.0002.massive_limit:0 "Set Massive Limit"
+ magic_build_manager.0002.monumental_limit:0 "Set Monumental Limit"
+ magic_build_manager.0002.clear_limit:0 "Clear Limit"
 
   # Terrain Localization
  clrbnit_magic_Wind_furnace_custom_tooltip:0 "Wind Furnace magical requirements met"

--- a/localization/english/magic_manager_l_english.yml
+++ b/localization/english/magic_manager_l_english.yml
@@ -38,6 +38,30 @@
  magic_build_manager.9999.exit:0 "Exit"
  magic_build_manager.0001.credits:0 "View Credits"
 
+ # New Key for Menu 0001:
+ magic_build_manager.0001.set_spending:0 "Configure Gold Reserve Limit"
+
+ # Set Spending Limit
+ magic_build_manager.0002.t:0 "Configure Magic Build Gold Reserve"
+ magic_build_manager.0002.desc:0 "This feature allows you to set a minimum threshold for your gold reserves (either personal gold or the Imperial Treasury). The Magic Build system will automatically block construction if the cost would reduce your available funds below this reserved amount. This is a safety margin to prevent accidental bankruptcy."
+ magic_build_manager.0002.back:0 "Back"
+
+ # ACTIVE (Greyed Out/Selected)
+ magic_build_manager.0002.tiny_limit_active:0 "50 Reserve (Selected)!"
+ magic_build_manager.0002.minor_limit_active:0 "150 Reserve (Selected)!"
+ magic_build_manager.0002.medium_limit_active:0 "300 Reserve (Selected)!"
+ magic_build_manager.0002.major_limit_active:0 "500 Reserve (Selected)!"
+ magic_build_manager.0002.massive_limit_active:0 "750 Reserve (Selected)!"
+ magic_build_manager.0002.monumental_limit_active:0 "1,500 Reserve (Selected)!"
+
+ # INACTIVE (Yellow/Clickable)
+ magic_build_manager.0002.tiny_limit_inactive:0 "Tiny Reserve: Keep 50 reserved"
+ magic_build_manager.0002.minor_limit_inactive:0 "Minor Reserve: Keep 150 reserved"
+ magic_build_manager.0002.medium_limit_inactive:0 "Medium Reserve: Keep 300 reserved"
+ magic_build_manager.0002.major_limit_inactive:0 "Major Reserve: Keep 500 reserved"
+ magic_build_manager.0002.massive_limit_inactive:0 "Massive Reserve: Keep 750 reserved"
+ magic_build_manager.0002.monumental_limit_inactive:0 "Monumental Reserve (Default): Keep 1,500 reserved"
+
   # Terrain Localization
  clrbnit_magic_Wind_furnace_custom_tooltip:0 "Wind Furnace magical requirements met"
  clrbnit_magic_Scriptorium_custom_tooltip:0 "Scriptorium magical requirements met"


### PR DESCRIPTION
Changes

- Treasury support; changed gold to treasury_or_gold
- Spending limit choices + GUI (Maybe should´ve named it savings instead)
- 6 limit options
- changed gold check logic for spend limit
- new files: spending_graphics.txt (optional), spending_effects.txt, spending_defaults.txt
- tested in-game with celestial gov´t

Notes

- spending limit options can be reduced if needed
- spending_graphics.txt completely optional. I just wanted to see the inactive choices. Could delete this completely and remove show_as_unavailable from the limit choices.
- gui could use some work